### PR TITLE
Change dockerfiles, kubernetes and docker_compose arguments to accept multiple values

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FRIZBEE_TOKEN }}
         with:
           actions: .github/workflows
-          dockerfiles: ./docker
-          kubernetes: ./k8s
-          docker_compose: ./docker
+          dockerfiles: ["./Dockerfile", "./images"] # You can specify multiple files or directories
+          kubernetes: ["./k8s"]
+          docker_compose: ["./docker"]
           open_pr: true
           fail_on_unpinned: true
 ```

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -33,20 +33,22 @@ import (
 )
 
 type FrizbeeAction struct {
-	Client            *github.Client
-	Token             string
-	RepoOwner         string
-	RepoName          string
-	ActionsPath       string
-	DockerfilesPath   string
-	KubernetesPath    string
-	DockerComposePath string
-	OpenPR            bool
-	FailOnUnpinned    bool
-	ActionsReplacer   *replacer.Replacer
-	ImagesReplacer    *replacer.Replacer
-	BFS               billy.Filesystem
-	Repo              *git.Repository
+	Client    *github.Client
+	Token     string
+	RepoOwner string
+	RepoName  string
+
+	ActionsPath        string
+	DockerfilesPaths   []string
+	KubernetesPaths    []string
+	DockerComposePaths []string
+
+	OpenPR          bool
+	FailOnUnpinned  bool
+	ActionsReplacer *replacer.Replacer
+	ImagesReplacer  *replacer.Replacer
+	BFS             billy.Filesystem
+	Repo            *git.Repository
 }
 
 // Run runs the frizbee action
@@ -91,7 +93,11 @@ func (fa *FrizbeeAction) parseWorkflowActions(ctx context.Context, out *replacer
 
 // parseImages parses the Dockerfiles, Docker Compose, and Kubernetes files for container images.
 func (fa *FrizbeeAction) parseImages(ctx context.Context, out *replacer.ReplaceResult) error {
-	pathsToParse := []string{fa.DockerfilesPath, fa.DockerComposePath, fa.KubernetesPath}
+	pathsToParse := []string{}
+	pathsToParse = append(pathsToParse, fa.DockerfilesPaths...)
+	pathsToParse = append(pathsToParse, fa.DockerComposePaths...)
+	pathsToParse = append(pathsToParse, fa.KubernetesPaths...)
+
 	for _, path := range pathsToParse {
 		if path == "" {
 			continue


### PR DESCRIPTION
It's not unusual to have multiple dockerfiles spread around the
codebase, so it would be useful to support that. This patch supports a
JSON-like array e.g. `["Dockerfile", "Dockerfile.dev"]`.

Fixes: #8
