### PR TITLE
Build and publish an image for frizbee-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Build and Publish Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the Docker image (default: latest)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@75c8b7a6935efd93a201fe28833fde3637be3970 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ fail the CI if unpinned actions are found and much more.
 
 The action is based on the Frizbee tool, available both as a CLI and as a library - https://github.com/stacklok/frizbee
 
+> Note: This action uses a pre-built Docker image from GHCR (`ghcr.io/stacklok/frizbee-action`) to improve performance and reduce build time during workflow execution.
+> The image is automatically built and published when a new release is created. Upon each release, the image reference in action.yml should be updated to the latest stable version.
+
 ## Table of Contents
 
 - [Usage](#usage)

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,6 @@ inputs:
     default: ""
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "Dockerfile" # "docker://ghcr.io/stacklok/frizbee-action:v0.0.4" Uncomment this line once we confirm the publishing works correctly
   args:
     - ${{ inputs.recursive }}


### PR DESCRIPTION
The following PR adds a build and publish release workflow for the frizbee action image. Once I confirm the publishing works, I'll update the action to use a published image instead of building the aciton from source.

Related: https://github.com/stacklok/frizbee-action/issues/100