### PR TITLE
Use a pre-built frizbee-action image (v0.0.4)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,6 @@ inputs:
     default: ""
 runs:
   using: "docker"
-  image: "Dockerfile" # "docker://ghcr.io/stacklok/frizbee-action:v0.0.4" Uncomment this line once we confirm the publishing works correctly
+  image: "docker://ghcr.io/stacklok/frizbee-action:v0.0.4" # Keep this updated with the latest version of the action image
   args:
     - ${{ inputs.recursive }}


### PR DESCRIPTION
The following PR moves away from building the image every time from source to a pre-built one